### PR TITLE
Update HACKING to change git to https and add webp dependency

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -15,7 +15,7 @@ Source code from GitHub
 -----------------------
 Checkout the source code by cloning it from GitHub
 
-    git clone git://github.com/gcompris/GCompris-qt.git
+    git clone https://github.com/gcompris/GCompris-qt.git
 
 If you want to have a personal fork, in order to commit occasional patches,
 fork it on GitHub then clone your fork
@@ -69,7 +69,11 @@ Installing dependencies on a Debian based systems can be done like this:
                           qttools5-dev-tools libqt5multimedia5-plugins \
                           qml-module-qtsensors libqt5quickparticles5 \
                           qml-module-qtquick2 qml-module-qtquick-particles2 \
-                          libqt5sensors5-dev libqt5sensors5 qml-module-qtcharts
+                          libqt5sensors5-dev libqt5sensors5 qml-module-qtcharts \
+                          qt5-image-formats-plugins
+
+                          
+                    
 
 To build for Android, Qt 5 AndroidExtras also needs to be installed.
 


### PR DESCRIPTION

NOTE: This is intended to be a merge only to my own fork. Sorry in advance if i've screwed this up.

When installing from these directions i needed to make some changes. 

I needed to use the command "git clone https://github.com/gcompris/GCompris-qt.git" instead of ".....git://...." otherwise the attempt would time out. 

After building i noticed images in the Categorisation activity would not show thumbnail images for "Colours", "Animals" , "Food" etc.  and clicking into Numbers would show the digits and letters (stored as .svg files) correctly, but other files (stored as .webp) were not shown.  running the command "sudo apt install qt5-image-formats-plugins" and recompiling showed the previously invisible images.
